### PR TITLE
Add learning section with link to bevy-cheatsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An [awesome](https://github.com/sindresorhus/awesome)-style list of cool Bevy projects. If you would like to share what you're working on, submit a PR! Feel free to create new categories where it makes sense.
 
+## Learning
+
+* [Bevy Cheatsheet](https://github.com/jamadazi/bevy-cheatsheet): Concise programming reference for Bevy!
+
 ## Plugins and Crates
 
 ### 3D


### PR DESCRIPTION
Add a new section for learning resources. Add my new Bevy Cheatsheet as the first link under the new section.

I made it the first section in the list, because I think that learning resources are what new visitors to the list would likely be looking for.

