### PR TITLE
Add physme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ An [awesome](https://github.com/sindresorhus/awesome)-style list of cool Bevy pr
 ### Physics
 
 * [bevy_rapier](https://github.com/dimforge/bevy_rapier): A plugin for Rapier, a 2D and 3D physics engine. Maintained by the Rapier developers.
+* [physme](https://github.com/walterpie/physme): A simplistic physics engine for both 2D and 3D simulation. Physically inaccurate, but feels satisfying and is easy to use.
 
 ### Networking
 


### PR DESCRIPTION
Add physme, a simple and satisfying, but physically inaccurate, 2d and 3d physics engine.