### PR TITLE
Replace cheatsheet/cookbook with cheatbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ An [awesome](https://github.com/sindresorhus/awesome)-style list of cool Bevy pr
 ## Learning
 
 * [Official Bevy Examples](https://github.com/bevyengine/bevy/tree/master/examples): Learn each Bevy feature from minimal illustrative examples
-* [Bevy Cheatsheet](https://github.com/jamadazi/bevy-cheatsheet): Concise programming reference for Bevy!
-* [Bevy Cookbook](https://github.com/jamadazi/bevy-cookbook): Concise recipes for common game dev tasks
+* [Bevy Cheatbook](https://bevy-cheatbook.github.io): Practical reference to programming in bevy! Covers basic concepts, syntax, and solutions to common game dev tasks!
+  * [Bevy Cheatsheet](https://bevy-cheatbook.github.io/cheatsheet/release.html): Condensed one-page summary of Bevy programming syntax.
 * [Understanding Bevy](https://alice-i-cecile.github.io/understanding-bevy/): An opinionated guide to Bevy's design patterns and inner workings.
 * [Making a Snake Clone](https://mbuffett.com/posts/bevy-snake-tutorial/): Walkthrough on how to make a snake clone
 * [Making Chess Clone in 3D](https://caballerocoll.com/blog/bevy-chess-tutorial): Walkthrough on how to make a Chess Clone with 3D pieces


### PR DESCRIPTION
The bevy cheatsheet and cheatbook have been superseded by the new bevy-cheatbook project.

Also provide a link directly to the cheatsheet page, as many people are likely to be looking specifically for that.