### PR TITLE
Add web builds to the description of bevy_game_template

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ These translations are unofficial, unverified, and potentially out of date.
 * [bevy_event_set](https://github.com/woubuc/bevy-event-set): A macro to create event bundles for Bevy
 
 ## Templates
-* [bevy_game_template](https://github.com/NiklasEi/bevy_game_template): An opinionated template repository for a Bevy game including a workflow for Windows, Linux and MacOS releases
+* [bevy_game_template](https://github.com/NiklasEi/bevy_game_template): An opinionated template repository for a Bevy game including a workflow for Windows, Linux, macOS and Web (WASM) releases
 
 ## Games
 


### PR DESCRIPTION
See title

I feel that this was an enough anticipated addition to add it to the description here.