### PR TITLE
Add `bevy_advanced_input` by Sadpython

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ These translations are unofficial, unverified, and potentially out of date.
 
 ## Plugins and Crates
 ### Input
+* [bevy_advanced_input](https://github.com/sadpython/bevy_advanced_input): Input keybindings, including support for combinations / hotkeys / modifier keys.
 * [Kurinji](https://crates.io/crates/kurinji): Input Map for bevy. Converts user input from different input hardware into game specific actions, eg. keyboard "Space" or joystick "A" can be mapped to "Jump" Action.  This allows decoupling of the game code from device specific input api.
 * [bevy_input_actionmap](https://github.com/lightsoutgames/bevy_input_actionmap): Maps key and gamepad events to actions in Bevy.
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ These translations are unofficial, unverified, and potentially out of date.
 ## Plugins and Crates
 ### Input
 * [bevy_advanced_input](https://github.com/sadpython/bevy_advanced_input): Input keybindings, including support for combinations / hotkeys / modifier keys.
-* [Kurinji](https://crates.io/crates/kurinji): Input Map for bevy. Converts user input from different input hardware into game specific actions, eg. keyboard "Space" or joystick "A" can be mapped to "Jump" Action.  This allows decoupling of the game code from device specific input api.
 * [bevy_input_actionmap](https://github.com/lightsoutgames/bevy_input_actionmap): Maps key and gamepad events to actions in Bevy.
+* [Kurinji](https://crates.io/crates/kurinji): Input Map for bevy. Converts user input from different input hardware into game specific actions, eg. keyboard "Space" or joystick "A" can be mapped to "Jump" Action.  This allows decoupling of the game code from device specific input api.
 
 ### 3D
 * [bevy_fly_camera](https://crates.io/crates/bevy_fly_camera): A flying camera plugin


### PR DESCRIPTION
This is not my crate, but the author asked me to submit it to awesome-bevy on his behalf.

I also decided to add a second commit to reorder the entries in the "Input" section, because I think it looks more aesthetically pleasing this way, now that there are more entries, and lists the more-recently-maintained crates first.

Feel free to ignore / not merge this second commit if you disagree. If you agree with it and want to merge it, consider *not* squashing the commits when merging; I think it will be cleaner in the git history if they are separate.