### PR TITLE
remove bevy cheatsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ An [awesome](https://github.com/sindresorhus/awesome)-style list of cool Bevy pr
 
 * [Official Bevy Examples](https://github.com/bevyengine/bevy/tree/latest/examples): Learn each Bevy feature from minimal illustrative examples
 * [Bevy Cheatbook](https://bevy-cheatbook.github.io): Practical reference to programming in bevy! Covers basic concepts, syntax, and solutions to common game dev tasks!
-  * [Bevy Cheatsheet](https://bevy-cheatbook.github.io/cheatsheet.html): Condensed one-page summary of Bevy programming syntax.
 * [Maz.digital Blog](https://maz.digital/bevy/list): Beginner-focused blog posts introducing Bevy's features.
 * [Making a Snake Clone](https://mbuffett.com/posts/bevy-snake-tutorial/): Walkthrough on how to make a snake clone
 * [Making Chess Clone in 3D](https://caballerocoll.com/blog/bevy-chess-tutorial): Walkthrough on how to make a Chess Clone with 3D pieces


### PR DESCRIPTION
This no longer seems to be a popular page, and is just a semi-neglected part of the Cheatbook, that has fallen behind the rest of the book. It doesn't deserve a separate link, and I am planning to remove it / replace it with something else.